### PR TITLE
feat: spotify 소셜 로그인 api 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -22,6 +22,7 @@ android {
         localProperties.load(FileInputStream(rootProject.file("local.properties")))
         val kakaoKey = localProperties.getProperty("KAKAO_NATIVE_APP_KEY") ?: ""
         buildConfigField("String", "KAKAO_NATIVE_APP_KEY", "\"$kakaoKey\"")
+        buildConfigField ("String", "SPOTIFY_REDIRECT_URI", "\"muaring://spotify-redirect\"")
 
         manifestPlaceholders["kakao_scheme"] =
             "kakao${localProperties.getProperty("KAKAO_NATIVE_APP_KEY")}"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".LoginActivity"/>
+        <activity
+            android:name=".LoginActivity"
+            android:exported="true"
+            android:launchMode="singleTask">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="muaring" android:host="spotify-redirect" />
+            </intent-filter>
+        </activity>
         <activity android:name=".MainActivity"/>
 
         <!--카카오 로그인 콜백 처리 액티비티-->

--- a/app/src/main/java/org/maru/muaring/LoginActivity.java
+++ b/app/src/main/java/org/maru/muaring/LoginActivity.java
@@ -1,22 +1,28 @@
 package org.maru.muaring;
 
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
-
+import android.widget.Toast;
 import androidx.appcompat.app.AppCompatActivity;
-
+import androidx.lifecycle.ViewModelProvider;
 import org.maru.muaring.feature.auth.navigation.LoginNavigator;
 import org.maru.muaring.feature.auth.ui.LoginFragment;
-
+import org.maru.muaring.feature.auth.ui.LoginState;
+import org.maru.muaring.feature.auth.ui.LoginViewModel;
 import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
 public class LoginActivity extends AppCompatActivity implements LoginNavigator {
 
+    private LoginViewModel loginViewModel;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_login);
+
+        loginViewModel = new ViewModelProvider(this).get(LoginViewModel.class);
 
         if (savedInstanceState == null) {
             getSupportFragmentManager()
@@ -24,6 +30,8 @@ public class LoginActivity extends AppCompatActivity implements LoginNavigator {
                     .replace(R.id.login_container, new LoginFragment())
                     .commit();
         }
+
+        observeLoginState();
     }
 
     @Override
@@ -32,4 +40,39 @@ public class LoginActivity extends AppCompatActivity implements LoginNavigator {
         startActivity(intent);
         finish();  // 로그인 화면 제거
     }
+
+    @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        handleSpotifyRedirect(intent);
+    }
+
+    private void handleSpotifyRedirect(Intent intent) {
+        Uri uri = intent.getData();
+
+        if (uri != null && uri.toString().startsWith(BuildConfig.SPOTIFY_REDIRECT_URI)) {
+
+            String code = uri.getQueryParameter("code");
+
+            if (code != null) {
+                loginViewModel.loginWithSpotifyCode(code, this);
+            } else {
+                String error = uri.getQueryParameter("error");
+                Toast.makeText(this, "Spotify 로그인 실패", Toast.LENGTH_SHORT).show();
+            }
+        }
+    }
+
+    private void observeLoginState() {
+        loginViewModel.getLoginState().observe(this, state -> {
+            if (state instanceof LoginState.Success) {
+                navigateToMain();
+            } else if (state instanceof LoginState.Error) {
+                String msg = ((LoginState.Error) state).message;
+                Toast.makeText(this, msg, Toast.LENGTH_SHORT).show();
+            }
+        });
+    }
+
 }

--- a/app/src/main/java/org/maru/muaring/SplashActivity.java
+++ b/app/src/main/java/org/maru/muaring/SplashActivity.java
@@ -23,6 +23,9 @@ public class SplashActivity extends AppCompatActivity {
         String keyHash = Utility.INSTANCE.getKeyHash(this);
         Log.d("KAKAO_KEY_HASH", "keyHash = " + keyHash);
 
+        // 앱 시작 시 토큰 삭제 후 시작 (임시)
+        TokenManager.clear(this);
+
         try {
             String token = tokenManager.getAccessToken();
 
@@ -41,17 +44,3 @@ public class SplashActivity extends AppCompatActivity {
         finish(); // SplashActivity 종료
     }
 }
-
-// 로그인 넘어가서 테스트
-//@AndroidEntryPoint
-//public class SplashActivity extends AppCompatActivity {
-//
-//    @Override
-//    protected void onCreate(Bundle savedInstanceState) {
-//        super.onCreate(savedInstanceState);
-//
-//        // ✅ 테스트용: 항상 메인으로
-//        startActivity(new Intent(this, MainActivity.class));
-//        finish();
-//    }
-//}

--- a/core/src/main/java/org/maru/muaring/core/TokenManager.java
+++ b/core/src/main/java/org/maru/muaring/core/TokenManager.java
@@ -37,4 +37,10 @@ public class TokenManager {
     public String getAccessToken() {
         return prefs.getString(ACCESS, null);
     }
+
+    // 저장된 토큰 삭제하는 임시 로직
+    public static void clear(Context context) {
+        SharedPreferences pref = context.getSharedPreferences(PREF, Context.MODE_PRIVATE);
+        pref.edit().clear().apply();
+    }
 }

--- a/core/src/main/java/org/maru/muaring/core/common/Callback.java
+++ b/core/src/main/java/org/maru/muaring/core/common/Callback.java
@@ -1,0 +1,7 @@
+package org.maru.muaring.core.common;
+
+public interface Callback<T> {
+
+    void onSuccess(T result);
+    void onError(Exception e);
+}

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -6,7 +6,7 @@ android {
     namespace = "org.maru.muaring.data"
     compileSdk = 36
     defaultConfig { minSdk = 24; targetSdk = 36 }
-    compileOptions { sourceCompatibility = JavaVersion.VERSION_11; targetCompatibility = JavaVersion.VERSION_11 }
+    compileOptions { sourceCompatibility = JavaVersion.VERSION_21; targetCompatibility = JavaVersion.VERSION_21 }
 }
 
 dependencies {

--- a/data/src/main/java/org/maru/muaring/data/api/AuthApi.java
+++ b/data/src/main/java/org/maru/muaring/data/api/AuthApi.java
@@ -1,6 +1,7 @@
 package org.maru.muaring.data.api;
 
 import org.maru.muaring.data.api.dto.LoginRequest;
+import org.maru.muaring.data.api.dto.KakaoLoginRequest;
 import org.maru.muaring.data.api.dto.LoginResponse;
 import org.maru.muaring.data.api.dto.ApiResponse;
 
@@ -12,4 +13,5 @@ public interface AuthApi {
 
     @POST("/auth/login/kakao")
     Call<ApiResponse<LoginResponse>> loginWithKakao(@Body LoginRequest request);
+    Call<ApiResponse<LoginResponse>> loginWithKakao(@Body KakaoLoginRequest request);
 }

--- a/data/src/main/java/org/maru/muaring/data/api/AuthApi.java
+++ b/data/src/main/java/org/maru/muaring/data/api/AuthApi.java
@@ -1,17 +1,24 @@
 package org.maru.muaring.data.api;
 
-import org.maru.muaring.data.api.dto.LoginRequest;
+import org.maru.muaring.data.api.dto.AuthorizeUrlResponse;
 import org.maru.muaring.data.api.dto.KakaoLoginRequest;
 import org.maru.muaring.data.api.dto.LoginResponse;
 import org.maru.muaring.data.api.dto.ApiResponse;
+import org.maru.muaring.data.api.dto.SpotifyLoginRequest;
 
 import retrofit2.Call;
 import retrofit2.http.Body;
+import retrofit2.http.GET;
 import retrofit2.http.POST;
 
 public interface AuthApi {
 
     @POST("/auth/login/kakao")
-    Call<ApiResponse<LoginResponse>> loginWithKakao(@Body LoginRequest request);
     Call<ApiResponse<LoginResponse>> loginWithKakao(@Body KakaoLoginRequest request);
+
+    @POST("/auth/login/spotify")
+    Call<ApiResponse<LoginResponse>> loginWithSpotify(@Body SpotifyLoginRequest request);
+
+    @GET("/auth/spotify/authorization")
+    Call<ApiResponse<AuthorizeUrlResponse>> getAuthorizedUrl();
 }

--- a/data/src/main/java/org/maru/muaring/data/api/dto/AuthorizeUrlResponse.java
+++ b/data/src/main/java/org/maru/muaring/data/api/dto/AuthorizeUrlResponse.java
@@ -1,0 +1,10 @@
+package org.maru.muaring.data.api.dto;
+
+public class AuthorizeUrlResponse {
+
+    private String authorizeUrl;
+
+    public String getAuthorizeUrl() {
+        return authorizeUrl;
+    }
+}

--- a/data/src/main/java/org/maru/muaring/data/api/dto/KakaoLoginRequest.java
+++ b/data/src/main/java/org/maru/muaring/data/api/dto/KakaoLoginRequest.java
@@ -1,10 +1,10 @@
 package org.maru.muaring.data.api.dto;
 
-public class LoginRequest {
+public class KakaoLoginRequest {
 
     private String kakaoAccessToken;
 
-    public LoginRequest(String accessToken) {
+    public KakaoLoginRequest(String accessToken) {
         this.kakaoAccessToken = accessToken;
     }
 }

--- a/data/src/main/java/org/maru/muaring/data/api/dto/SpotifyLoginRequest.java
+++ b/data/src/main/java/org/maru/muaring/data/api/dto/SpotifyLoginRequest.java
@@ -1,0 +1,10 @@
+package org.maru.muaring.data.api.dto;
+
+public class SpotifyLoginRequest {
+
+    private String code;
+
+    public SpotifyLoginRequest(String code) {
+        this.code = code;
+    }
+}

--- a/data/src/main/java/org/maru/muaring/data/repository/AuthRepository.java
+++ b/data/src/main/java/org/maru/muaring/data/repository/AuthRepository.java
@@ -1,13 +1,11 @@
 package org.maru.muaring.data.repository;
 
+import org.maru.muaring.core.common.Callback;
 import org.maru.muaring.data.api.dto.LoginResponse;
 
 public interface AuthRepository {
 
-//    interface LoginCallback {
-//        void onSuccess(LoginResponse response);
-//        void onError(String message);
-//    }
+    void loginWithKakao(String kakaoToken, Callback<LoginResponse> callback);
 
     LoginResponse loginWithKakao(String kakaoToken) throws Exception;
 }

--- a/data/src/main/java/org/maru/muaring/data/repository/AuthRepository.java
+++ b/data/src/main/java/org/maru/muaring/data/repository/AuthRepository.java
@@ -7,5 +7,7 @@ public interface AuthRepository {
 
     void loginWithKakao(String kakaoToken, Callback<LoginResponse> callback);
 
-    LoginResponse loginWithKakao(String kakaoToken) throws Exception;
+    void getSpotifyAuthorizeUrl(Callback<String> callback);
+
+    void loginWithSpotifyCode(String spotifyCode, Callback<LoginResponse> callback);
 }

--- a/data/src/main/java/org/maru/muaring/data/repository/AuthRepositoryImpl.java
+++ b/data/src/main/java/org/maru/muaring/data/repository/AuthRepositoryImpl.java
@@ -1,9 +1,12 @@
 package org.maru.muaring.data.repository;
 
+import org.maru.muaring.core.common.Callback;
 import org.maru.muaring.data.api.dto.ApiResponse;
 import org.maru.muaring.data.api.dto.LoginRequest;
+import org.maru.muaring.data.api.dto.KakaoLoginRequest;
 import org.maru.muaring.data.api.dto.LoginResponse;
 import org.maru.muaring.data.api.AuthApi;
+import retrofit2.Call;
 import retrofit2.Response;
 
 public class AuthRepositoryImpl implements AuthRepository {
@@ -13,12 +16,43 @@ public class AuthRepositoryImpl implements AuthRepository {
     public AuthRepositoryImpl(AuthApi api) {
         this.api = api;
     }
+
     @Override
-    public LoginResponse loginWithKakao(String kakaoAccessToken) throws Exception {
-        LoginRequest request = new LoginRequest(kakaoAccessToken);
+    public void loginWithKakao(String kakaoAccessToken, Callback<LoginResponse> callback) {
+        KakaoLoginRequest request = new KakaoLoginRequest(kakaoAccessToken);
 
         Response<ApiResponse<LoginResponse>> response
                 = api.loginWithKakao(request).execute();  // 동기 호출
+        // enqueue()를 사용해 비동기 요청 시작 (UI 스레드를 막지 않아 앱이 멈추지 않도록 함)
+        api.loginWithKakao(request).enqueue(new retrofit2.Callback<>() {
+
+            // 통신 성공 (백그라운드 스레드)
+            @Override
+            public void onResponse(
+                    Call<ApiResponse<LoginResponse>> call,
+                    Response<ApiResponse<LoginResponse>> response
+            ) {
+
+                if (response.isSuccessful() && response.body() != null && response.body().getData() != null) {  // 성공
+                    LoginResponse data = response.body().getData();
+                    callback.onSuccess(data);
+
+                } else {  // 에러
+                    callback.onError(new Exception(response.code() + " 오류가 발생했습니다."));
+                }
+            }
+
+            // 통신 실패 (네트워크 연결, 타임아웃 등)
+            @Override
+            public void onFailure(
+                    Call<ApiResponse<LoginResponse>> call,
+                    Throwable t
+            ) {
+                // 네트워크 통신 오류
+                callback.onError(new Exception(t.getMessage() + " 네트워크 오류가 발생했습니다.")); // 콜백 실패 호출
+            }
+        });
+    }
 
         if (response.isSuccessful() && response.body().getData() != null) {
             return response.body().getData();

--- a/data/src/main/java/org/maru/muaring/data/repository/AuthRepositoryImpl.java
+++ b/data/src/main/java/org/maru/muaring/data/repository/AuthRepositoryImpl.java
@@ -2,10 +2,11 @@ package org.maru.muaring.data.repository;
 
 import org.maru.muaring.core.common.Callback;
 import org.maru.muaring.data.api.dto.ApiResponse;
-import org.maru.muaring.data.api.dto.LoginRequest;
+import org.maru.muaring.data.api.dto.AuthorizeUrlResponse;
 import org.maru.muaring.data.api.dto.KakaoLoginRequest;
 import org.maru.muaring.data.api.dto.LoginResponse;
 import org.maru.muaring.data.api.AuthApi;
+import org.maru.muaring.data.api.dto.SpotifyLoginRequest;
 import retrofit2.Call;
 import retrofit2.Response;
 
@@ -21,8 +22,6 @@ public class AuthRepositoryImpl implements AuthRepository {
     public void loginWithKakao(String kakaoAccessToken, Callback<LoginResponse> callback) {
         KakaoLoginRequest request = new KakaoLoginRequest(kakaoAccessToken);
 
-        Response<ApiResponse<LoginResponse>> response
-                = api.loginWithKakao(request).execute();  // 동기 호출
         // enqueue()를 사용해 비동기 요청 시작 (UI 스레드를 막지 않아 앱이 멈추지 않도록 함)
         api.loginWithKakao(request).enqueue(new retrofit2.Callback<>() {
 
@@ -54,10 +53,68 @@ public class AuthRepositoryImpl implements AuthRepository {
         });
     }
 
-        if (response.isSuccessful() && response.body().getData() != null) {
-            return response.body().getData();
-        } else {
-            throw new Exception("로그인 실패");
-        }
+    @Override
+    public void getSpotifyAuthorizeUrl(Callback<String> callback) {
+        api.getAuthorizedUrl().enqueue(new retrofit2.Callback<>() {
+            @Override
+            public void onResponse(
+                    Call<ApiResponse<AuthorizeUrlResponse>> call,
+                    Response<ApiResponse<AuthorizeUrlResponse>> response
+            ) {
+                if (!response.isSuccessful() || response.body() == null) {
+                    callback.onError(new Exception(
+                            response.code() + ": Spotify authorize URL 요청 중 오류가 발생했습니다."
+                    ));
+                    return;
+                }
+
+                ApiResponse<AuthorizeUrlResponse> apiRes = response.body();
+
+                if (apiRes.getData() == null || apiRes.getData().getAuthorizeUrl() == null) {
+                    callback.onError(new Exception("서버 응답에 authorize URL이 없습니다."));
+                    return;
+                }
+
+                callback.onSuccess(apiRes.getData().getAuthorizeUrl());
+            }
+
+            @Override
+            public void onFailure(Call<ApiResponse<AuthorizeUrlResponse>> call, Throwable t) {
+                callback.onError(new Exception(t.getMessage() + "네트워크 오류가 발생했습니다."));
+            }
+        });
     }
+
+    @Override
+    public void loginWithSpotifyCode(String spotifyCode, Callback<LoginResponse> callback) {
+        SpotifyLoginRequest request = new SpotifyLoginRequest(spotifyCode);
+        api.loginWithSpotify(request).enqueue(new retrofit2.Callback<>() {
+            @Override
+            public void onResponse(Call<ApiResponse<LoginResponse>> call,
+                                   Response<ApiResponse<LoginResponse>> response) {
+
+                if (!response.isSuccessful() || response.body() == null) {
+                    callback.onError(new Exception(
+                            response.code() + ": 스포티파이 로그인 중 오류가 발생했습니다."
+                    ));
+                    return;
+                }
+
+                ApiResponse<LoginResponse> apiRes = response.body();
+
+                if (apiRes.getData() == null) {
+                    callback.onError(new Exception("서버 응답에 데이터가 없습니다."));
+                    return;
+                }
+
+                callback.onSuccess(apiRes.getData());
+            }
+
+            @Override
+            public void onFailure(Call<ApiResponse<LoginResponse>> call, Throwable t) {
+                callback.onError(new Exception(t));
+            }
+        });
+    }
+
 }

--- a/design/build.gradle.kts
+++ b/design/build.gradle.kts
@@ -5,7 +5,7 @@ android {
     compileSdk = 36
     defaultConfig { minSdk = 24; targetSdk = 36 }
     buildFeatures { viewBinding = true }
-    compileOptions { sourceCompatibility = JavaVersion.VERSION_11; targetCompatibility = JavaVersion.VERSION_11 }
+    compileOptions { sourceCompatibility = JavaVersion.VERSION_21; targetCompatibility = JavaVersion.VERSION_21 }
 }
 
 dependencies {

--- a/feature/build.gradle.kts
+++ b/feature/build.gradle.kts
@@ -8,7 +8,7 @@ android {
     compileSdk = 36
     defaultConfig { minSdk = 24; targetSdk = 36 }
     buildFeatures { viewBinding = true }
-    compileOptions { sourceCompatibility = JavaVersion.VERSION_11; targetCompatibility = JavaVersion.VERSION_11 }
+    compileOptions { sourceCompatibility = JavaVersion.VERSION_21; targetCompatibility = JavaVersion.VERSION_21 }
 }
 
 dependencies {

--- a/feature/src/main/java/org/maru/muaring/feature/auth/ui/LoginFragment.java
+++ b/feature/src/main/java/org/maru/muaring/feature/auth/ui/LoginFragment.java
@@ -1,8 +1,8 @@
 package org.maru.muaring.feature.auth.ui;
 
 import android.content.Context;
+import android.net.Uri;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -10,6 +10,7 @@ import android.widget.Button;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
@@ -63,18 +64,6 @@ public class LoginFragment extends Fragment {
         observeLoginState();
     }
 
-    private void loginWithKakaoAccount() {
-        UserApiClient.getInstance().loginWithKakaoAccount(requireActivity(), (accountToken, accountError) -> {
-            if (accountError != null) {
-                Log.e("KAKAO_FLOW", "카카오 계정 로그인 실패", accountError);
-            } else if (accountToken != null) {
-                Log.d("KAKAO_FLOW", "카카오 계정 로그인 성공, accessToken=" + accountToken.getAccessToken());
-                viewModel.loginWithKakao(accountToken.getAccessToken(), requireContext());
-            }
-            return null;
-        });
-    }
-
     @Override
     public void onAttach(@NonNull Context context) {
         super.onAttach(context);
@@ -89,7 +78,7 @@ public class LoginFragment extends Fragment {
     }
 
     private void observeLoginState() {
-        viewModel.getLoginState().observe(getViewLifecycleOwner(), state -> {
+        loginViewModel.getLoginState().observe(getViewLifecycleOwner(), state -> {
 
             if (state instanceof LoginState.Loading) {
                 // TODO: 로딩 progress bar 표시 (컴포넌트 이용 예정)
@@ -100,6 +89,11 @@ public class LoginFragment extends Fragment {
 
                 // 로그인 화면 Activity 종료
                 requireActivity().finish();
+            }
+            else if (state instanceof  LoginState.SpotifyUrl) {
+                String url = ((LoginState.SpotifyUrl) state).url;
+                CustomTabsIntent intent = new CustomTabsIntent.Builder().build();
+                intent.launchUrl(requireContext(), Uri.parse(url));
             }
             else if (state instanceof LoginState.Error) {
                 String msg = ((LoginState.Error) state).message;

--- a/feature/src/main/java/org/maru/muaring/feature/auth/ui/LoginFragment.java
+++ b/feature/src/main/java/org/maru/muaring/feature/auth/ui/LoginFragment.java
@@ -21,7 +21,7 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class LoginFragment extends Fragment {
 
-    private LoginViewModel viewModel;
+    private LoginViewModel loginViewModel;
     private LoginNavigator navigator;
 
     @Override
@@ -33,28 +33,31 @@ public class LoginFragment extends Fragment {
     @Override
     public void onViewCreated(View view, Bundle savedInstanceState) {
         // HiltViewModel 가져오기
-        viewModel = new ViewModelProvider(this).get(LoginViewModel.class);
+        loginViewModel = new ViewModelProvider(this).get(LoginViewModel.class);
+
+        // 카카오 로그인
         Button kakaoLoginBtn = view.findViewById(R.id.btnKakaoLogin);
         kakaoLoginBtn.setOnClickListener(v -> {
-            Log.d("KAKAO_FLOW", "카카오 로그인 버튼 클릭됨");
+            UserApiClient.getInstance().loginWithKakaoTalk(requireActivity(), (token, error) -> {
+                if (error != null) {
+                    // 카톡 앱 로그인 실패 -> 웹 로그인
+                    UserApiClient.getInstance().loginWithKakaoAccount(requireActivity(), (accountToken, accountError) -> {
+                        if (accountToken != null) {
+                            loginViewModel.loginWithKakao(accountToken.getAccessToken(), requireContext());
+                        }
+                        return null;
+                    });
+                } else if (token != null) {
+                    loginViewModel.loginWithKakao(token.getAccessToken(), requireContext());
+                }
+                return null;
+            });
+        });
 
-            if (UserApiClient.getInstance().isKakaoTalkLoginAvailable(requireContext())) {
-                // 카카오톡으로
-                UserApiClient.getInstance().loginWithKakaoTalk(requireActivity(), (token, error) -> {
-                    if (error != null) {
-                        Log.e("KAKAO_FLOW", "카카오톡 로그인 실패", error);
-                        loginWithKakaoAccount();
-                    } else if (token != null) {
-                        Log.d("KAKAO_FLOW", "카카오톡 로그인 성공, accessToken=" + token.getAccessToken());
-                        viewModel.loginWithKakao(token.getAccessToken(), requireContext());
-                    }
-                    return null;
-                });
-            } else {
-                // 웹 계정 로그인
-                Log.d("KAKAO_FLOW", "카카오톡 미설치, 웹 로그인 진행");
-                loginWithKakaoAccount();
-            }
+        // 스포티파이 로그인
+        Button spotifyLoginBtn = view.findViewById(R.id.btnSpotifyLogin);
+        spotifyLoginBtn.setOnClickListener(v -> {
+            loginViewModel.startSpotifyLogin(requireContext());
         });
 
         observeLoginState();

--- a/feature/src/main/java/org/maru/muaring/feature/auth/ui/LoginState.java
+++ b/feature/src/main/java/org/maru/muaring/feature/auth/ui/LoginState.java
@@ -23,4 +23,11 @@ public abstract class LoginState {
             this.message = message;
         }
     }
+
+    public static class SpotifyUrl extends LoginState {
+        public final String url;
+        public SpotifyUrl(String url) {
+            this.url = url;
+        }
+    }
 }

--- a/feature/src/main/java/org/maru/muaring/feature/auth/ui/LoginViewModel.java
+++ b/feature/src/main/java/org/maru/muaring/feature/auth/ui/LoginViewModel.java
@@ -8,7 +8,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.inject.Inject;
 import dagger.hilt.android.lifecycle.HiltViewModel;
-
+import org.maru.muaring.core.common.Callback;
 import org.maru.muaring.core.TokenManager;
 import org.maru.muaring.data.api.dto.LoginResponse;
 import org.maru.muaring.data.repository.AuthRepository;
@@ -34,14 +34,20 @@ public class LoginViewModel extends ViewModel {
     public void loginWithKakao(String token, Context context) {
         loginState.setValue(new LoginState.Loading());
 
-        executor.execute(() -> {
-            try {
-                LoginResponse response = repository.loginWithKakao(token);
+        repository.loginWithKakao(token, new Callback<LoginResponse>() {
+            @Override
+            public void onSuccess(LoginResponse response) {
+                try {
+                    TokenManager.save(context, response.getAccessToken(), response.getRefreshToken());
+                    loginState.postValue(new LoginState.Success(response));
+                } catch (Exception e) {
+                    loginState.postValue(new LoginState.Error("토큰 저장 실패: " + e.getMessage()));
+                }
+            }
 
-                TokenManager.save(context, response.getAccessToken(), response.getRefreshToken());
-
-                loginState.postValue(new LoginState.Success(response));
-            } catch (Exception e) {
+            @Override
+            public void onError(Exception e) {
+                // UI에 실패 알림
                 loginState.postValue(new LoginState.Error(e.getMessage()));
             }
         });

--- a/feature/src/main/java/org/maru/muaring/feature/auth/ui/LoginViewModel.java
+++ b/feature/src/main/java/org/maru/muaring/feature/auth/ui/LoginViewModel.java
@@ -52,4 +52,40 @@ public class LoginViewModel extends ViewModel {
             }
         });
     }
+
+    // ⚪ Spotify 로그인 flow 시작 → authorize URL 받기
+    public void startSpotifyLogin(Context context) {
+        loginState.setValue(new LoginState.Loading());
+
+        repository.getSpotifyAuthorizeUrl(new Callback<>() {
+            @Override
+            public void onSuccess(String authorizeUrl) {
+                loginState.postValue(new LoginState.SpotifyUrl(authorizeUrl));
+            }
+
+            @Override
+            public void onError(Exception e) {
+                loginState.postValue(new LoginState.Error("스포티파이 Authorized URL 요청에 실패했습니다. : " + e.getMessage()));
+            }
+        });
+    }
+
+    // ⚪ redirect 후 받은 code 로 서버 로그인
+    public void loginWithSpotifyCode(String code, Context context) {
+        loginState.setValue(new LoginState.Loading());
+
+        repository.loginWithSpotifyCode(code, new Callback<LoginResponse>() {
+            @Override
+            public void onSuccess(LoginResponse response) {
+                // 토큰 저장
+                TokenManager.save(context, response.getAccessToken(), response.getRefreshToken());
+                loginState.postValue(new LoginState.Success(response));
+            }
+
+            @Override
+            public void onError(Exception e) {
+                loginState.postValue(new LoginState.Error("로그인 실패: " + e.getMessage()));
+            }
+        });
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
관련있는 이슈 번호(#000)을 적어주세요.
해당 pull request merge와 함께 이슈를 닫으려면
closed #12

## ✨ 작업 내용
- spotify 소셜 로그인 api을 연동했습니다.
- 현재 refresh token 관련 로직이 구현되지 않아 다시 시작하면 토큰을 SharedPreferences에서 삭제하도록 했습니다.
- 추가적으로 자바 버전이 11(....)로 되어있길래 21로 변경해두었습니다. -> 변경 후에도 에러 발생 X

## 📸 스크린샷(선택)
스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
참고, 논의할 사항이 있다면 적어주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Spotify 로그인 기능 추가
  * OAuth 리다이렉트를 통한 깊은 링크 처리 추가로 향상된 인증 환경 제공

* **개선 사항**
  * 로그인 상태 관리 및 비동기 처리 개선
  * 앱 시작 시 기존 토큰 초기화로 더 안전한 로그인 환경 구성

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->