### PR TITLE
[FEAT] 공개 그룹 가입 및 아이템 클릭 시 그룹 프로필 조회 기능 추가

### DIFF
--- a/app/src/main/java/org/maru/muaring/MainActivity.java
+++ b/app/src/main/java/org/maru/muaring/MainActivity.java
@@ -11,10 +11,12 @@ import androidx.navigation.ui.NavigationUI;
 
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
+import org.maru.muaring.feature.search.ui.SearchNavigator;
+
 import dagger.hilt.android.AndroidEntryPoint;
 
 @AndroidEntryPoint
-public class MainActivity extends AppCompatActivity {
+public class MainActivity extends AppCompatActivity implements SearchNavigator {
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -40,5 +42,36 @@ public class MainActivity extends AppCompatActivity {
         BottomNavigationView bottom = findViewById(R.id.bottomNav);
         NavigationUI.setupWithNavController(bottom, nav);
         // 이걸로 bottomNav <-> nav_main.xml 연결 전부 해줌
+    }
+
+    // SearchNavigator 구현: 여기서만 nav_main.xml 리소스 사용
+    @Override
+    public void openGroupProfile(long groupId) {
+        NavHostFragment host = (NavHostFragment) getSupportFragmentManager()
+                .findFragmentById(R.id.nav_host);
+
+        if (host == null) return;
+
+        NavController nav = host.getNavController();
+
+        Bundle args = new Bundle();
+        args.putLong("groupId", groupId);
+
+//        nav.navigate(R.id.groupProfileFragment, args);
+
+        // R.id.groupProfileFragment 대신 이름으로 id 가져오기
+        int destId = getResources().getIdentifier(
+                "groupProfileFragment",   // nav_main.xml에서 쓴 id 이름
+                "id",
+                getPackageName()
+        );
+
+        if (destId == 0) {
+            // 혹시라도 못 찾으면 토스트만 띄우고 리턴
+            Toast.makeText(this, "groupProfileFragment id 를 찾을 수 없어요 🥲", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        nav.navigate(destId, args);
     }
 }

--- a/app/src/main/res/navigation/nav_main.xml
+++ b/app/src/main/res/navigation/nav_main.xml
@@ -1,40 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_main"
     app:startDestination="@id/homeFragment">
 
+    <!-- 홈 -->
     <fragment
         android:id="@+id/homeFragment"
         android:name="org.maru.muaring.feature.home.ui.HomeFragment" />
 
+    <!-- 검색창 -->
     <fragment
         android:id="@+id/searchFragment"
         android:name="org.maru.muaring.feature.search.ui.SearchFragment" />
 
+    <!-- 가운데 업로드 -->
+    <fragment
+        android:id="@+id/musicSearchFragment"
+        android:name="org.maru.muaring.feature.upload.ui.MusicSearchFragment" />
+
+    <!-- 보관함 -->
     <fragment
         android:id="@+id/archiveFragment"
         android:name="org.maru.muaring.feature.archive.ui.ArchiveFragment" />
 
-<!--    <fragment-->
-<!--        android:id="@+id/profileFragment"-->
-<!--        android:name="org.maru.muaring.feature.member.ui.profile.MemberProfileFragment" />-->
-
-<!--     그룹 프로필 테스트-->
+    <!-- 사용자 프로필 -->
     <fragment
         android:id="@+id/profileFragment"
-        android:name="org.maru.muaring.feature.group.ui.profile.GroupProfileFragment"
-        android:label="Group Profile">
-
-        <argument
-            android:name="groupId"
-            app:argType="long" />
-    </fragment>
-
-    <!-- 가운데 업로드 FAB 목적지 -->
-    <fragment
-        android:id="@+id/musicSearchFragment"
-        android:name="org.maru.muaring.feature.upload.ui.MusicSearchFragment" />
+        android:name="org.maru.muaring.feature.member.ui.profile.MemberProfileFragment" />
 
     <fragment
         android:id="@+id/mapFragment"
@@ -45,5 +39,14 @@
         android:id="@+id/libraryFragment"
         android:name="org.maru.muaring.feature.library.ui.LibraryFragment"
         />
+
+    <fragment
+        android:id="@+id/groupProfileFragment"
+        android:name="org.maru.muaring.feature.group.ui.profile.GroupProfileFragment"
+        tools:layout="@layout/fragment_group_profile">
+        <argument
+            android:name="groupId"
+            app:argType="long" />
+    </fragment>
 
 </navigation>

--- a/data/src/main/java/org/maru/muaring/data/api/GroupApi.java
+++ b/data/src/main/java/org/maru/muaring/data/api/GroupApi.java
@@ -70,5 +70,10 @@ public interface GroupApi {
             @Path("groupId") Long groupId
     );
 
+    // 공개 그룹 가입
+    @POST("/groups/{groupId}/members")
+    Call<ApiResponse<Void>> joinPublicGroup(
+            @Path("groupId") Long groupId
+    );
 
 }

--- a/data/src/main/java/org/maru/muaring/data/repository/GroupRepository.java
+++ b/data/src/main/java/org/maru/muaring/data/repository/GroupRepository.java
@@ -48,4 +48,11 @@ public interface GroupRepository {
     Call<ApiResponse<List<GroupCategoryResponse>>> getGroupCategories();
 
     LiveData<Resource<GroupProfileResponse>> getGroupProfile(Long groupId);
+
+    void joinPublicGroup(Long groupId, JoinGroupCallback callback);
+
+    interface JoinGroupCallback {
+        void onSuccess();
+        void onError(Throwable t);
+    }
 }

--- a/data/src/main/java/org/maru/muaring/data/repository/GroupRepositoryImpl.java
+++ b/data/src/main/java/org/maru/muaring/data/repository/GroupRepositoryImpl.java
@@ -44,6 +44,7 @@ public class GroupRepositoryImpl implements GroupRepository {
         this.groupApi = groupApi;
     }
 
+    
     @Override
     public LiveData<Resource<GroupInviteResponse>> createInviteLink(Long groupId) {
         MutableLiveData<Resource<GroupInviteResponse>> result = new MutableLiveData<>();
@@ -101,6 +102,7 @@ public class GroupRepositoryImpl implements GroupRepository {
         return result;
     }
 
+    
     @Override
     public LiveData<Resource<InvitePreviewResponse>> getInvitePreview(String inviteToken) {
         MutableLiveData<Resource<InvitePreviewResponse>> result = new MutableLiveData<>();
@@ -158,6 +160,7 @@ public class GroupRepositoryImpl implements GroupRepository {
         return result;
     }
 
+    
     @Override
     public LiveData<Resource<Void>> joinByInviteToken(String inviteToken) {
         MutableLiveData<Resource<Void>> result = new MutableLiveData<>();
@@ -212,7 +215,8 @@ public class GroupRepositoryImpl implements GroupRepository {
 
         return result;
     }
-
+    
+    
     // 그룹 검색
     @Override
     public void searchGroups(String name, int page, int size, SearchGroupsCallback callback) {
@@ -251,8 +255,8 @@ public class GroupRepositoryImpl implements GroupRepository {
             }
         });
     }
-
-
+    
+    
     // 그룹 카테고리 조회
     @Override
     public Call<ApiResponse<List<GroupCategoryResponse>>> getGroupCategories() {
@@ -290,6 +294,7 @@ public class GroupRepositoryImpl implements GroupRepository {
     }
 
 
+    // 그룹 프로필 조회
     @Override
     public LiveData<Resource<GroupProfileResponse>> getGroupProfile(Long groupId) {
         MutableLiveData<Resource<GroupProfileResponse>> result = new MutableLiveData<>();
@@ -330,4 +335,29 @@ public class GroupRepositoryImpl implements GroupRepository {
 
         return result;
     }
+
+    
+    // 공개 그룹 가입
+    @Override
+    public void joinPublicGroup(Long groupId, JoinGroupCallback callback) {
+        groupApi.joinPublicGroup(groupId)
+                .enqueue(new Callback<ApiResponse<Void>>() {
+                    @Override
+                    public void onResponse(Call<ApiResponse<Void>> call,
+                                           Response<ApiResponse<Void>> response) {
+
+                        if (response.isSuccessful()) {
+                            callback.onSuccess();
+                        } else {
+                            callback.onError(new Exception("가입 실패 code=" + response.code()));
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Call<ApiResponse<Void>> call, Throwable t) {
+                        callback.onError(t);
+                    }
+                });
+    }
+
 }

--- a/feature/src/main/java/org/maru/muaring/feature/group/ui/profile/GroupProfileFragment.java
+++ b/feature/src/main/java/org/maru/muaring/feature/group/ui/profile/GroupProfileFragment.java
@@ -85,13 +85,12 @@ public class GroupProfileFragment extends Fragment {
 
         // === groupId 전달 받기 (네비게이션 또는 Bundle 등) ===
         if (getArguments() != null) {
-            groupId = getArguments().getLong("groupId", 1); // TODO: 하드코딩 해둔 거라서 이 부분 전달받게 바꿔야 됨!!!
-        }
-
-        if (groupId == null || groupId <= 0) {
-            Toast.makeText(requireContext(), "유효하지 않은 그룹입니다.", Toast.LENGTH_SHORT).show();
-            requireActivity().onBackPressed();
-            return;
+            if (!getArguments().containsKey("groupId")) {
+                throw new IllegalStateException("groupId가 전달되지 않았습니다.");
+            }
+            groupId = getArguments().getLong("groupId");
+        } else {
+            throw new IllegalStateException("GroupProfileFragment의 인자값이 없습니다.");
         }
 
         viewModel = new ViewModelProvider(this).get(GroupProfileViewModel.class);

--- a/feature/src/main/java/org/maru/muaring/feature/search/ui/SearchFragment.java
+++ b/feature/src/main/java/org/maru/muaring/feature/search/ui/SearchFragment.java
@@ -1,5 +1,6 @@
 package org.maru.muaring.feature.search.ui;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -44,8 +45,19 @@ public class SearchFragment extends Fragment {
     private SearchBarFragment searchBarFragment;        // 검색창
     private SearchResultAdapter searchResultAdapter;
 
+    private SearchNavigator navigator;
+
     @Inject
     GroupRepository groupRepository;
+
+    // Activity를 navigator로 받기
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        if (context instanceof SearchNavigator) {
+            navigator = (SearchNavigator) context;
+        }
+    }
 
     @Nullable
     @Override
@@ -81,14 +93,60 @@ public class SearchFragment extends Fragment {
         updateUIForGroupSearch();
     }
 
+
     private void setupRecyclerView() {
         recyclerSearchResult.setLayoutManager(new LinearLayoutManager(requireContext()));
-        searchResultAdapter = new SearchResultAdapter(item -> {
-            if (item.getType() == SearchResultItem.Type.GROUP) {
-                // TODO: 그룹 가입/상세 이동
-                // navigateToGroupDetail(item.getId());
-            } else {
-                // TODO: 사용자 팔로우/프로필 이동
+
+        searchResultAdapter = new SearchResultAdapter(new SearchResultAdapter.OnItemActionClickListener() {
+            @Override
+            public void onItemClick(SearchResultItem item) {
+                // 카드 전체 클릭 → 그룹 프로필 화면으로 이동
+                if (item.getType() == SearchResultItem.Type.GROUP) {
+                    Long groupId = item.getId();
+
+                    if (navigator != null) {
+                        navigator.openGroupProfile(groupId);   // 여기서 Activity에게 부탁
+                    }
+                } else {
+                    // TODO: 사용자 프로필 이동
+                }
+            }
+
+            @Override
+            public void onActionClick(SearchResultItem item) {
+                // 버튼 클릭 → 가입 처리
+                if (item.getType() == SearchResultItem.Type.GROUP) {
+
+                    // 이미 참여 중이면 클릭 막기
+                    if (Boolean.TRUE.equals(item.getIsJoined())) return;
+
+                    Long groupId = item.getId();
+
+                    groupRepository.joinPublicGroup(groupId, new GroupRepository.JoinGroupCallback() {
+                        @Override
+                        public void onSuccess() {
+                            if (!isAdded()) return;
+
+                            Toast.makeText(requireContext(), "가입을 완료했어요! 🎵", Toast.LENGTH_SHORT).show();
+
+                            // 가입 상태 변경
+                            item.setIsJoined(true);
+                            item.setActionText("가입 중");
+
+                            // 어댑터에 반영
+                            searchResultAdapter.refreshItem(item);
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {
+                            if (!isAdded()) return;
+
+                            Toast.makeText(requireContext(), "가입에 실패했어요. 🥲", Toast.LENGTH_SHORT).show();
+                        }
+                    });
+                } else {
+                    // TODO: 사용자 팔로우
+                }
             }
         });
         recyclerSearchResult.setAdapter(searchResultAdapter);
@@ -211,4 +269,5 @@ public class SearchFragment extends Fragment {
         // 지금은 빈 처리
         Toast.makeText(requireContext(), "사용자 검색 API 연결 예정", Toast.LENGTH_SHORT).show();
     }
+
 }

--- a/feature/src/main/java/org/maru/muaring/feature/search/ui/SearchNavigator.java
+++ b/feature/src/main/java/org/maru/muaring/feature/search/ui/SearchNavigator.java
@@ -1,0 +1,6 @@
+package org.maru.muaring.feature.search.ui;
+
+// 콜백 인터페이스
+public interface SearchNavigator {
+    void openGroupProfile(long groupId);
+}

--- a/feature/src/main/java/org/maru/muaring/feature/search/ui/adapter/SearchResultAdapter.java
+++ b/feature/src/main/java/org/maru/muaring/feature/search/ui/adapter/SearchResultAdapter.java
@@ -21,7 +21,8 @@ import java.util.List;
 public class SearchResultAdapter extends RecyclerView.Adapter<SearchResultAdapter.ResultViewHolder> {
 
     public interface OnItemActionClickListener {
-        void onActionClick(SearchResultItem item);
+        void onItemClick(SearchResultItem item);   // 카드 전체 클릭
+        void onActionClick(SearchResultItem item); // 버튼 클릭
     }
 
     private final List<SearchResultItem> items = new ArrayList<>();
@@ -166,12 +167,26 @@ public class SearchResultAdapter extends RecyclerView.Adapter<SearchResultAdapte
                 containerExtra.addView(extra);
             }
 
+            // 카드 전체 클릭 → onItemClick
+            itemView.setOnClickListener(v -> {
+                if (listener != null) {
+                    listener.onItemClick(item);
+                }
+            });
+
+            // 버튼 클릭 → onActionClick
             btnAction.setOnClickListener(v -> {
                 // 이미 참여 중이면 클릭 막기
                 if (Boolean.TRUE.equals(item.getIsJoined())) return;
-
                 if (listener != null) listener.onActionClick(item);
             });
+        }
+    }
+
+    public void refreshItem(SearchResultItem item) {
+        int index = items.indexOf(item);
+        if (index != -1) {
+            notifyItemChanged(index);
         }
     }
 }

--- a/feature/src/main/java/org/maru/muaring/feature/search/ui/model/SearchResultItem.java
+++ b/feature/src/main/java/org/maru/muaring/feature/search/ui/model/SearchResultItem.java
@@ -12,10 +12,10 @@ public class SearchResultItem {
     private final Type type;
     private final Long id;
     private final String title;
-    private final List<String> categoryNames; // 그룹용
-    private final String todayMusicText;      // 사용자용
-    private final String actionText;          // 버튼 텍스트
-    private final Boolean isJoined;
+    private final List<String> categoryNames;   // 그룹용
+    private final String todayMusicText;        // 사용자용
+    private String actionText;                  // 버튼 텍스트
+    private Boolean isJoined;                   // 가입 여부
 
     public SearchResultItem(Type type,
                             Long id,
@@ -40,4 +40,12 @@ public class SearchResultItem {
     public String getTodayMusicText() { return todayMusicText; }
     public String getActionText() { return actionText; }
     public Boolean getIsJoined() { return isJoined; }
+
+    // setter
+    public void setActionText(String actionText) {
+        this.actionText = actionText;
+    }
+    public void setIsJoined(Boolean joined) {
+        this.isJoined = joined;
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
#2

## ✨ 작업 내용
- 그룹 검색창에서 가입하지 않은 그룹의 '가입' 버튼을 클릭하면 해당 그룹에 가입할 수 있는 기능을 추가했습니다.
- 버튼 대신 그룹 아이템을 클릭하면 해당 그룹의 프로필을 조회할 수 있습니다.

## 📸 스크린샷(선택)
X

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
X