### PR TITLE
[FEAT] 사용자 검색 기능 및 검색창 내 팔로우 기능 추가

### DIFF
--- a/data/src/main/java/org/maru/muaring/data/api/FollowApi.java
+++ b/data/src/main/java/org/maru/muaring/data/api/FollowApi.java
@@ -1,0 +1,23 @@
+package org.maru.muaring.data.api;
+
+import org.maru.muaring.data.api.dto.ApiResponse;
+import org.maru.muaring.data.api.dto.FollowResponseDTO;
+
+import retrofit2.Call;
+import retrofit2.http.DELETE;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+public interface FollowApi {
+
+    @POST("/follow/request")
+    Call<ApiResponse<FollowResponseDTO>> followMember(
+            @Query("followeeId") Long memberId
+    );
+
+    @DELETE("/follow/unfollow")
+    Call<ApiResponse<Void>> unfollowMember(
+            @Query("followeeId") Long memberId
+    );
+}

--- a/data/src/main/java/org/maru/muaring/data/api/MemberApi.java
+++ b/data/src/main/java/org/maru/muaring/data/api/MemberApi.java
@@ -5,8 +5,10 @@ import org.maru.muaring.data.api.dto.MemberProfileCreateRequest;
 import org.maru.muaring.data.api.dto.MemberProfileCreateResponse;
 import org.maru.muaring.data.api.dto.MemberProfileSettingReadResponse;
 import org.maru.muaring.data.api.dto.MemberProfileUpdateRequest;
+import org.maru.muaring.data.api.dto.MemberSearchItemDto;
 import org.maru.muaring.data.api.dto.MemberSettingsResponse;
 import org.maru.muaring.data.api.dto.NicknameCheckResponse;
+import org.maru.muaring.data.api.dto.PageResponse;
 
 import retrofit2.Call;
 import retrofit2.http.Body;
@@ -32,4 +34,12 @@ public interface MemberApi {
 
     @PATCH("/me/profile")
     Call<ApiResponse<Void>> updateProfile(@Body MemberProfileUpdateRequest request);
+
+    @GET("/members/search")
+    Call<ApiResponse<PageResponse<MemberSearchItemDto>>> searchMembers(
+            @Query("name") String name,
+            @Query("page") int page,
+            @Query("size") int size
+    );
+
 }

--- a/data/src/main/java/org/maru/muaring/data/api/dto/FollowResponseDTO.java
+++ b/data/src/main/java/org/maru/muaring/data/api/dto/FollowResponseDTO.java
@@ -1,0 +1,30 @@
+package org.maru.muaring.data.api.dto;
+
+public class FollowResponseDTO {
+
+    private Long followId;
+    private Long followerId;
+    private Long followeeId;
+    private String status;
+    private String createdAt;   // LocalDateTime으로 못 받아온다고 했던 것 가틈
+
+    public Long getFollowId() {
+        return followId;
+    }
+
+    public Long getFolloweeId() {
+        return followeeId;
+    }
+
+    public Long getFollowerId() {
+        return followerId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/data/src/main/java/org/maru/muaring/data/api/dto/MemberSearchItemDto.java
+++ b/data/src/main/java/org/maru/muaring/data/api/dto/MemberSearchItemDto.java
@@ -1,0 +1,22 @@
+package org.maru.muaring.data.api.dto;
+
+public class MemberSearchItemDto {
+
+    private Long memberId;
+    private String nickname;
+    private String profileImageUrl;
+    private Boolean isPublic;
+    private Boolean isFollowing;
+
+    private String todayMusicName;
+    private String todayMusicArtistName;
+
+    public Long getMemberId() { return memberId; }
+    public String getNickname() { return nickname; }
+    public String getProfileImageUrl() { return profileImageUrl; }
+    public Boolean getIsPublic() { return isPublic; }
+    public Boolean getIsFollowing() { return isFollowing; }
+    public void setIsFollowing(Boolean following) { this.isFollowing = following; }
+    public String getTodayMusicName() { return todayMusicName; }
+    public String getTodayMusicArtistName() { return todayMusicArtistName; }
+}

--- a/data/src/main/java/org/maru/muaring/data/di/NetworkModule.java
+++ b/data/src/main/java/org/maru/muaring/data/di/NetworkModule.java
@@ -2,6 +2,7 @@ package org.maru.muaring.data.di;
 
 import org.maru.muaring.core.network.AuthInterceptor;
 import org.maru.muaring.data.api.AuthApi;
+import org.maru.muaring.data.api.FollowApi;
 import org.maru.muaring.data.api.GroupApi;
 import org.maru.muaring.data.api.HistoryApi;
 import org.maru.muaring.data.api.ImageApi;
@@ -11,6 +12,8 @@ import org.maru.muaring.data.api.PostApi;
 import org.maru.muaring.data.api.UploadApi;
 import org.maru.muaring.data.repository.AuthRepository;
 import org.maru.muaring.data.repository.AuthRepositoryImpl;
+import org.maru.muaring.data.repository.FollowRepository;
+import org.maru.muaring.data.repository.FollowRepositoryImpl;
 import org.maru.muaring.data.repository.GroupRepository;
 import org.maru.muaring.data.repository.GroupRepositoryImpl;
 import org.maru.muaring.data.repository.HistoryRepository;
@@ -144,5 +147,17 @@ public class NetworkModule {
     @Singleton
     public UploadRepository provideMusicRepository(UploadApi api) {
         return new UploadRepositoryImpl(api);
+    }
+
+    @Provides
+    @Singleton
+    public FollowApi provideFollowApi(Retrofit retrofit) {
+        return retrofit.create(FollowApi.class);
+    }
+
+    @Provides
+    @Singleton
+    public FollowRepository provideFollowRepository(FollowApi api) {
+        return new FollowRepositoryImpl(api);
     }
 }

--- a/data/src/main/java/org/maru/muaring/data/repository/FollowRepository.java
+++ b/data/src/main/java/org/maru/muaring/data/repository/FollowRepository.java
@@ -1,0 +1,19 @@
+package org.maru.muaring.data.repository;
+
+import org.maru.muaring.core.common.Callback;
+import org.maru.muaring.data.api.dto.MemberSearchItemDto;
+
+import java.util.List;
+
+public interface FollowRepository {
+
+    void followMember(long memberId, Callback<Void> callback);
+
+    void unfollowMember(long memberId, Callback<Void> callback);
+
+    interface SearchMembersCallback {
+        void onSuccess(List<MemberSearchItemDto> members);
+        void onError(Throwable t);
+    }
+
+}

--- a/data/src/main/java/org/maru/muaring/data/repository/FollowRepositoryImpl.java
+++ b/data/src/main/java/org/maru/muaring/data/repository/FollowRepositoryImpl.java
@@ -1,0 +1,74 @@
+package org.maru.muaring.data.repository;
+
+import org.maru.muaring.core.common.Callback;
+import org.maru.muaring.data.api.FollowApi;
+import org.maru.muaring.data.api.dto.ApiResponse;
+import org.maru.muaring.data.api.dto.FollowResponseDTO;
+
+import retrofit2.Call;
+import retrofit2.Response;
+
+public class FollowRepositoryImpl implements FollowRepository {
+
+    private final FollowApi api;
+
+    public FollowRepositoryImpl(FollowApi api) {
+        this.api = api;
+    }
+
+    @Override
+    public void followMember(long memberId, Callback<Void> callback) {
+
+        api.followMember(memberId)
+                .enqueue(new retrofit2.Callback<ApiResponse<FollowResponseDTO>>() {
+
+                    @Override
+                    public void onResponse(
+                            Call<ApiResponse<FollowResponseDTO>> call,
+                            Response<ApiResponse<FollowResponseDTO>> response
+                    ) {
+                        if (response.isSuccessful() && response.body() != null) {
+                            callback.onSuccess(null); // 성공 시 데이터 필요 없음
+                        } else {
+                            callback.onError(new Exception("팔로우 요청 실패"));
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(
+                            Call<ApiResponse<FollowResponseDTO>> call,
+                            Throwable t
+                    ) {
+                        callback.onError(new Exception("네트워크 오류", t));
+                    }
+                });
+    }
+
+    @Override
+    public void unfollowMember(long memberId, Callback<Void> callback) {
+
+        api.unfollowMember(memberId)
+                .enqueue(new retrofit2.Callback<ApiResponse<Void>>() {
+
+                    @Override
+                    public void onResponse(
+                            Call<ApiResponse<Void>> call,
+                            Response<ApiResponse<Void>> response
+                    ) {
+                        if (response.isSuccessful()) {
+                            callback.onSuccess(null);
+                        } else {
+                            callback.onError(new Exception("언팔로우 실패"));
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(
+                            Call<ApiResponse<Void>> call,
+                            Throwable t
+                    ) {
+                        callback.onError(new Exception("네트워크 오류", t));
+                    }
+                });
+    }
+}

--- a/data/src/main/java/org/maru/muaring/data/repository/MemberRepository.java
+++ b/data/src/main/java/org/maru/muaring/data/repository/MemberRepository.java
@@ -6,10 +6,13 @@ import org.maru.muaring.core.common.Callback;
 import org.maru.muaring.core.util.Resource;
 import org.maru.muaring.data.api.dto.MemberProfileCreateRequest;
 import org.maru.muaring.data.api.dto.MemberProfileCreateResponse;
+import org.maru.muaring.data.api.dto.MemberSearchItemDto;
 import org.maru.muaring.data.api.dto.MemberSettingsResponse;
 import org.maru.muaring.data.api.dto.MemberProfileSettingReadResponse;
 import org.maru.muaring.data.api.dto.MemberProfileUpdateRequest;
 import org.maru.muaring.data.api.dto.NicknameCheckResponse;
+
+import java.util.List;
 
 public interface MemberRepository {
 
@@ -19,4 +22,11 @@ public interface MemberRepository {
     void updateProfile(MemberProfileUpdateRequest request, Callback<Void> callback);
 
     LiveData<Resource<MemberSettingsResponse>> getMySettings();
+
+    void searchMembers(String name, int page, int size, SearchMembersCallback callback);
+
+    interface SearchMembersCallback {
+        void onSuccess(List<MemberSearchItemDto> members);
+        void onError(Throwable t);
+    }
 }

--- a/data/src/main/java/org/maru/muaring/data/repository/MemberRepositoryImpl.java
+++ b/data/src/main/java/org/maru/muaring/data/repository/MemberRepositoryImpl.java
@@ -1,5 +1,7 @@
 package org.maru.muaring.data.repository;
 
+import android.util.Log;
+
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 
@@ -9,10 +11,15 @@ import org.maru.muaring.data.api.MemberApi;
 import org.maru.muaring.data.api.dto.ApiResponse;
 import org.maru.muaring.data.api.dto.MemberProfileCreateRequest;
 import org.maru.muaring.data.api.dto.MemberProfileCreateResponse;
+import org.maru.muaring.data.api.dto.MemberSearchItemDto;
 import org.maru.muaring.data.api.dto.MemberSettingsResponse;
 import org.maru.muaring.data.api.dto.MemberProfileSettingReadResponse;
 import org.maru.muaring.data.api.dto.MemberProfileUpdateRequest;
 import org.maru.muaring.data.api.dto.NicknameCheckResponse;
+import org.maru.muaring.data.api.dto.PageResponse;
+
+import java.util.List;
+
 import retrofit2.Call;
 import retrofit2.Response;
 
@@ -141,4 +148,53 @@ public class MemberRepositoryImpl implements MemberRepository {
             }
         });
     }
+
+    @Override
+    public void searchMembers(
+            String name,
+            int page,
+            int size,
+            SearchMembersCallback callback
+    ) {
+        api.searchMembers(name, page, size)
+                .enqueue(new retrofit2.Callback<ApiResponse<PageResponse<MemberSearchItemDto>>>() {
+                    @Override
+                    public void onResponse(
+                            Call<ApiResponse<PageResponse<MemberSearchItemDto>>> call,
+                            Response<ApiResponse<PageResponse<MemberSearchItemDto>>> response
+                    ) {
+                        if (response.isSuccessful() && response.body() != null) {
+
+                            ApiResponse<PageResponse<MemberSearchItemDto>> body = response.body();
+                            PageResponse<MemberSearchItemDto> pageResponse = body.getData();
+
+                            // 로그 찍어서 실제로 몇 개 오는지 확인
+                            int count = 0;
+                            if (pageResponse != null && pageResponse.getContent() != null) {
+                                count = pageResponse.getContent().size();
+                            }
+                            Log.d("MemberRepository", "searchMembers success, count = " + count);
+
+                            List<MemberSearchItemDto> content =
+                                    (pageResponse != null && pageResponse.getContent() != null)
+                                            ? pageResponse.getContent()
+                                            : java.util.Collections.emptyList();
+
+                            callback.onSuccess(content);
+
+                        } else {
+                            callback.onError(new Exception("멤버 검색에 실패했어요."));
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(
+                            Call<ApiResponse<PageResponse<MemberSearchItemDto>>> call,
+                            Throwable t
+                    ) {
+                        callback.onError(t);
+                    }
+                });
+    }
+
 }

--- a/design/src/main/res/drawable/bg_button_following.xml
+++ b/design/src/main/res/drawable/bg_button_following.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/white" />
+
+    <corners android:radius="10dp" />
+
+    <stroke
+        android:width="2dp"
+        android:color="@color/black" />
+</shape>

--- a/design/src/main/res/layout/item_group_avatar.xml
+++ b/design/src/main/res/layout/item_group_avatar.xml
@@ -6,13 +6,21 @@
     android:gravity="center_horizontal"
     android:paddingHorizontal="4dp">
 
-    <ImageView
-        android:id="@+id/ivAvatar"
+    <!-- 바깥 컨테이너: 여기 배경에 stroke 적용 -->
+    <FrameLayout
+        android:id="@+id/avatarContainer"
         android:layout_width="60dp"
         android:layout_height="60dp"
-        android:background="@drawable/bg_circle_gray"
-        android:scaleType="centerCrop"
-        android:padding="12dp" />
+        android:background="@drawable/bg_circle_gray">
+
+        <ImageView
+            android:id="@+id/ivAvatar"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:scaleType="centerCrop"
+            android:padding="12dp" />
+        <!-- 여기에는 background 지정 X -->
+    </FrameLayout>
 
     <TextView
         android:id="@+id/tvLabel"

--- a/feature/src/main/java/org/maru/muaring/feature/home/ui/adapter/GroupSelectorAdapter.java
+++ b/feature/src/main/java/org/maru/muaring/feature/home/ui/adapter/GroupSelectorAdapter.java
@@ -151,9 +151,11 @@ public class GroupSelectorAdapter extends RecyclerView.Adapter<GroupSelectorAdap
 
         // 선택 여부에 따라 stroke 적용
         if (isSelected) {
-            holder.ivAvatar.setBackgroundResource(org.maru.muaring.design.R.drawable.bg_avatar_selected);
+            holder.ivAvatar.setBackgroundResource(
+                    org.maru.muaring.design.R.drawable.bg_avatar_selected);
         } else {
-            holder.ivAvatar.setBackgroundResource(org.maru.muaring.design.R.drawable.bg_circle_gray);
+            holder.ivAvatar.setBackgroundResource(
+                    org.maru.muaring.design.R.drawable.bg_circle_gray);
         }
 
         holder.itemView.setOnClickListener(v -> {
@@ -216,11 +218,13 @@ public class GroupSelectorAdapter extends RecyclerView.Adapter<GroupSelectorAdap
     }
 
     static class AvatarViewHolder extends RecyclerView.ViewHolder {
+        View avatarContainer;
         ImageView ivAvatar;
         TextView tvLabel;
 
         AvatarViewHolder(@NonNull View itemView) {
             super(itemView);
+            avatarContainer = itemView.findViewById(org.maru.muaring.design.R.id.avatarContainer);
             ivAvatar = itemView.findViewById(org.maru.muaring.design.R.id.ivAvatar);
             tvLabel = itemView.findViewById(org.maru.muaring.design.R.id.tvLabel);
         }

--- a/feature/src/main/java/org/maru/muaring/feature/search/ui/SearchFragment.java
+++ b/feature/src/main/java/org/maru/muaring/feature/search/ui/SearchFragment.java
@@ -17,18 +17,20 @@ import androidx.navigation.fragment.NavHostFragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import org.maru.muaring.core.common.Callback;
 import org.maru.muaring.core.ui.SegmentedToggleView;
 import org.maru.muaring.data.api.dto.GroupSummary;
+import org.maru.muaring.data.api.dto.MemberSearchItemDto;
+import org.maru.muaring.data.repository.FollowRepository;
 import org.maru.muaring.data.repository.GroupRepository;
+import org.maru.muaring.data.repository.MemberRepository;
 import org.maru.muaring.feature.R;
 import org.maru.muaring.feature.common.SearchBarFragment;
 import org.maru.muaring.feature.search.ui.adapter.SearchResultAdapter;
 import org.maru.muaring.feature.search.ui.model.SearchResultItem;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -37,6 +39,11 @@ import dagger.hilt.android.AndroidEntryPoint;
 @AndroidEntryPoint
 public class SearchFragment extends Fragment {
 
+    // Toolbar
+    private TextView toolbarTitle;
+    private ImageButton toolbarBack;
+    private ImageButton toolbarAction;
+
     private SegmentedToggleView segmentedToggleView;    // 상단 토글
     private ImageButton btnBack;                        // 뒤로가기 버튼
     private TextView textTitle;
@@ -44,11 +51,18 @@ public class SearchFragment extends Fragment {
 
     private SearchBarFragment searchBarFragment;        // 검색창
     private SearchResultAdapter searchResultAdapter;
+    private TextView tvEmptyResult;                     // 빈 결과 조회
 
     private SearchNavigator navigator;
 
     @Inject
     GroupRepository groupRepository;
+
+    @Inject
+    MemberRepository memberRepository;
+
+    @Inject
+    FollowRepository followRepository;
 
     // Activity를 navigator로 받기
     @Override
@@ -72,10 +86,27 @@ public class SearchFragment extends Fragment {
                               @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
+        initToolbar(view);
         initViews(view);
         setupInitialState();
         setupListeners();
         setupRecyclerView();
+    }
+
+    private void initToolbar(@NonNull View root) {
+        View toolbar = root.findViewById(R.id.include_toolbar_group);
+        if (toolbar == null) return;
+
+        toolbarTitle = toolbar.findViewById(org.maru.muaring.core.R.id.toolbar_title);
+        toolbarBack = toolbar.findViewById(R.id.btn_back);
+//        toolbarAction = toolbar.findViewById(org.maru.muaring.core.R.id.toolbar_action);
+
+        toolbarTitle.setText("검색");
+        toolbarBack.setOnClickListener(v -> requireActivity().onBackPressed());
+//        toolbarAction.setVisibility(View.VISIBLE);
+//        toolbarAction.setOnClickListener(v -> {
+//            // TODO: 그룹 설정 이동
+//        });
     }
 
     private void initViews(View view) {
@@ -85,6 +116,7 @@ public class SearchFragment extends Fragment {
         searchBarFragment = (SearchBarFragment) getChildFragmentManager()
                 .findFragmentById(R.id.fragmentSearchBar);
         recyclerSearchResult = view.findViewById(R.id.recyclerSearchResult);
+        tvEmptyResult = view.findViewById(R.id.tvEmptyResult);
     }
 
     private void setupInitialState() {
@@ -127,7 +159,7 @@ public class SearchFragment extends Fragment {
                         public void onSuccess() {
                             if (!isAdded()) return;
 
-                            Toast.makeText(requireContext(), "가입을 완료했어요! 🎵", Toast.LENGTH_SHORT).show();
+                            Toast.makeText(requireContext(), item.getTitle() + " 가입을 완료했어요! 🎵", Toast.LENGTH_SHORT).show();
 
                             // 가입 상태 변경
                             item.setIsJoined(true);
@@ -141,14 +173,67 @@ public class SearchFragment extends Fragment {
                         public void onError(Throwable t) {
                             if (!isAdded()) return;
 
-                            Toast.makeText(requireContext(), "가입에 실패했어요. 🥲", Toast.LENGTH_SHORT).show();
+                            Toast.makeText(requireContext(), item.getTitle() + " 가입에 실패했어요 🥲", Toast.LENGTH_SHORT).show();
                         }
                     });
                 } else {
                     // TODO: 사용자 팔로우
+                    long memberId = item.getId();
+
+                    // -------------------------
+                    // UNFOLLOW
+                    // -------------------------
+                    if (Boolean.TRUE.equals(item.getIsFollowing())) {
+
+                        followRepository.unfollowMember(memberId, new Callback<Void>() {
+                            @Override
+                            public void onSuccess(Void result) {
+                                if (!isAdded()) return;
+
+                                item.setIsFollowing(false);
+                                item.setActionText("팔로우");
+                                searchResultAdapter.refreshItem(item);
+
+                                Toast.makeText(requireContext(), item.getTitle() + " 님을 언팔로우했어요.", Toast.LENGTH_SHORT).show();
+                            }
+
+                            @Override
+                            public void onError(Exception e) {
+                                if (!isAdded()) return;
+                                Toast.makeText(requireContext(), "언팔로우 실패", Toast.LENGTH_SHORT).show();
+                            }
+                        });
+
+                    }
+
+                    // -------------------------
+                    // FOLLOW
+                    // -------------------------
+                    else {
+
+                        followRepository.followMember(memberId, new org.maru.muaring.core.common.Callback<Void>() {
+                            @Override
+                            public void onSuccess(Void result) {
+                                if (!isAdded()) return;
+
+                                Toast.makeText(requireContext(), item.getTitle() + " 님을 팔로우했어요! 🎵", Toast.LENGTH_SHORT).show();
+
+                                item.setIsFollowing(true);
+                                item.setActionText("팔로잉");
+                                searchResultAdapter.refreshItem(item);
+                            }
+
+                            @Override
+                            public void onError(Exception e) {
+                                if (!isAdded()) return;
+                                Toast.makeText(requireContext(), "팔로우에 실패했어요 🥲", Toast.LENGTH_SHORT).show();
+                            }
+                        });
+                    }
                 }
             }
         });
+
         recyclerSearchResult.setAdapter(searchResultAdapter);
     }
 
@@ -213,7 +298,7 @@ public class SearchFragment extends Fragment {
         if (segmentedToggleView.isGroupSelected()) {
             searchGroups(query);
         } else {
-            searchUsers(query);
+            searchMembers(query);
         }
     }
 
@@ -223,6 +308,13 @@ public class SearchFragment extends Fragment {
                     @Override
                     public void onSuccess(List<GroupSummary> groups) {
                         if (!isAdded()) return;
+
+                        if (groups == null || groups.isEmpty()) {
+                            updateEmptyView(true);
+                            searchResultAdapter.clear();
+                            return;
+                        }
+                        updateEmptyView(false);
 
                         List<SearchResultItem> items = new ArrayList<>();
                         for (GroupSummary g : groups) {
@@ -238,7 +330,9 @@ public class SearchFragment extends Fragment {
                                     categoryNames,
                                     null,
                                     actionText,
-                                    joined
+                                    joined,
+                                    null,
+                                    g.getImageUrl()
                             ));
                         }
                         searchResultAdapter.setItems(items);
@@ -253,21 +347,68 @@ public class SearchFragment extends Fragment {
     }
 
 
-    private void searchUsers(String query) {
+    private void searchMembers(String query) {
         // TODO: 사용자 검색 API 연동 후 SearchResultItem.Type.USER 로 매핑
 
-//        items.add(new SearchResultItem(
-//                SearchResultItem.Type.USER,
-//                u.getUserId(),
-//                u.getNickname(),
-//                null,
-//                todayMusic,
-//                "팔로우",
-//                null   // isJoined 안 씀
-//        ));
+        memberRepository.searchMembers(query, 0, 10,
+                new MemberRepository.SearchMembersCallback() {
+                    @Override
+                    public void onSuccess(List<MemberSearchItemDto> members) {
+                        if (!isAdded()) return;
 
-        // 지금은 빈 처리
-        Toast.makeText(requireContext(), "사용자 검색 API 연결 예정", Toast.LENGTH_SHORT).show();
+                        if (members == null || members.isEmpty()) {
+                            updateEmptyView(true);
+                            searchResultAdapter.clear();
+                            return;
+                        }
+                        updateEmptyView(false);
+
+                        List<SearchResultItem> items = new ArrayList<>();
+
+                        for (MemberSearchItemDto m : members) {
+
+                            // 오늘의 음악 한 줄 만들기
+                            String today = null;
+                            if (m.getTodayMusicName() != null && m.getTodayMusicArtistName() != null) {
+                                today = m.getTodayMusicName() + " - " + m.getTodayMusicArtistName();
+                            }
+
+                            boolean following = Boolean.TRUE.equals(m.getIsFollowing());
+                            String actionText = following ? "팔로잉" : "팔로우";
+
+                            items.add(new SearchResultItem(
+                                    SearchResultItem.Type.USER,     // 멤버 타입
+                                    m.getMemberId(),                  // id
+                                    m.getNickname(),                  // 제목(닉네임)
+                                    null,                             // 카테고리 없음 (그룹 전용)
+                                    today,                            // 오늘의 음악 텍스트
+                                    actionText,                       // 버튼 텍스트
+                                    null,                             // isJoined (그룹 전용)
+                                    following,                        // isFollowing (멤버 전용)
+                                    m.getProfileImageUrl()
+                            ));
+                        }
+
+                        searchResultAdapter.setItems(items);
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        if (!isAdded()) return;
+                        Toast.makeText(requireContext(),
+                                "멤버 검색 실패", Toast.LENGTH_SHORT).show();
+                    }
+                });
+    }
+
+    private void updateEmptyView(boolean isEmpty) {
+        if (isEmpty) {
+            tvEmptyResult.setVisibility(View.VISIBLE);
+            recyclerSearchResult.setVisibility(View.GONE);
+        } else {
+            tvEmptyResult.setVisibility(View.GONE);
+            recyclerSearchResult.setVisibility(View.VISIBLE);
+        }
     }
 
 }

--- a/feature/src/main/java/org/maru/muaring/feature/search/ui/adapter/SearchResultAdapter.java
+++ b/feature/src/main/java/org/maru/muaring/feature/search/ui/adapter/SearchResultAdapter.java
@@ -12,6 +12,8 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.bumptech.glide.Glide;
+
 import org.maru.muaring.feature.R;
 import org.maru.muaring.feature.search.ui.model.SearchResultItem;
 
@@ -79,6 +81,18 @@ public class SearchResultAdapter extends RecyclerView.Adapter<SearchResultAdapte
         void bind(SearchResultItem item) {
             LayoutInflater inflater = LayoutInflater.from(itemView.getContext());
 
+            ivThumbnail.setImageResource(org.maru.muaring.design.R.drawable.bg_group_circle);
+
+            String imageUrl = item.getImageUrl();
+            if (imageUrl != null && !imageUrl.isEmpty()) {
+                Glide.with(itemView.getContext())
+                        .load(imageUrl)
+                        .placeholder(org.maru.muaring.design.R.drawable.bg_group_circle)
+                        .error(org.maru.muaring.design.R.drawable.bg_group_circle)
+                        .circleCrop()
+                        .into(ivThumbnail);
+            }
+
             tvTitle.setText(item.getTitle());
             btnAction.setText(item.getActionText());
 
@@ -121,7 +135,7 @@ public class SearchResultAdapter extends RecyclerView.Adapter<SearchResultAdapte
 
                 if (joined) {
                     btnAction.setText("가입 중");
-                    btnAction.setEnabled(false);
+//                    btnAction.setEnabled(false);
                     btnAction.setBackgroundResource(
                             org.maru.muaring.design.R.drawable.bg_button_group_joined
                     );
@@ -140,7 +154,7 @@ public class SearchResultAdapter extends RecyclerView.Adapter<SearchResultAdapte
                     );
                 }
 
-            } else { // USER
+            } else { // 멤버 검색 결과
                 View extra = inflater.inflate(
                         R.layout.view_search_user_extra,
                         containerExtra,
@@ -151,20 +165,56 @@ public class SearchResultAdapter extends RecyclerView.Adapter<SearchResultAdapte
 
                 String today = item.getTodayMusicText();
                 if (today != null && !today.isEmpty()) {
-                    ivMusicIcon.setImageResource(org.maru.muaring.design.R.drawable.ic_today_music_active);
+                    ivMusicIcon.setImageResource(
+                            org.maru.muaring.design.R.drawable.ic_today_music_active
+                    );
                     tvMusicInfo.setText(today);
                     tvMusicInfo.setTextColor(
-                            itemView.getResources().getColor(org.maru.muaring.design.R.color.green)
+                            itemView.getResources().getColor(
+                                    org.maru.muaring.design.R.color.green
+                            )
                     );
                 } else {
-                    ivMusicIcon.setImageResource(org.maru.muaring.design.R.drawable.ic_today_music_inactive);
+                    ivMusicIcon.setImageResource(
+                            org.maru.muaring.design.R.drawable.ic_today_music_inactive
+                    );
                     tvMusicInfo.setText("오늘의 음악을 등록하지 않았습니다.");
                     tvMusicInfo.setTextColor(
-                            itemView.getResources().getColor(org.maru.muaring.design.R.color.text_light_gray)
+                            itemView.getResources().getColor(
+                                    org.maru.muaring.design.R.color.text_light_gray
+                            )
                     );
                 }
 
                 containerExtra.addView(extra);
+
+                // ==== 멤버용 버튼: isFollowing 에 따라 스타일 분기 ====
+                btnAction.setBackgroundTintList(null);
+                boolean following = Boolean.TRUE.equals(item.getIsFollowing());
+
+                if (following) {
+                    // 팔로잉 상태 → 흰 배경
+                    btnAction.setText("팔로잉");
+                    btnAction.setEnabled(true); // 언팔 가능해야 하니까 활성화 유지
+                    btnAction.setBackgroundResource(
+                            org.maru.muaring.design.R.drawable.bg_button_group_joined
+                    );
+                    btnAction.setTextColor(
+                            itemView.getResources().getColor(
+                                    org.maru.muaring.design.R.color.black
+                            )
+                    );
+                } else {
+                    // 팔로우 전 상태 → 초록 버튼
+                    btnAction.setText("팔로우");
+                    btnAction.setEnabled(true);
+                    btnAction.setBackgroundResource(
+                            org.maru.muaring.design.R.drawable.bg_button_group_join
+                    );
+                    btnAction.setTextColor(
+                            itemView.getResources().getColor(android.R.color.white)
+                    );
+                }
             }
 
             // 카드 전체 클릭 → onItemClick
@@ -176,8 +226,11 @@ public class SearchResultAdapter extends RecyclerView.Adapter<SearchResultAdapte
 
             // 버튼 클릭 → onActionClick
             btnAction.setOnClickListener(v -> {
-                // 이미 참여 중이면 클릭 막기
-                if (Boolean.TRUE.equals(item.getIsJoined())) return;
+                // 그룹인 경우 참여 중이면 막기
+                if (item.getType() == SearchResultItem.Type.GROUP &&
+                        Boolean.TRUE.equals(item.getIsJoined())) {
+                    return;
+                }
                 if (listener != null) listener.onActionClick(item);
             });
         }

--- a/feature/src/main/java/org/maru/muaring/feature/search/ui/group/GroupSearchFragment.java
+++ b/feature/src/main/java/org/maru/muaring/feature/search/ui/group/GroupSearchFragment.java
@@ -38,7 +38,7 @@ public class GroupSearchFragment extends Fragment {
 
             @Override
             public void onUserSelected() {
-                // 네비게이션으로 UserSearchFragment로 이동
+                // 네비게이션으로 MemberSearchFragment로 이동
                 // NavController nav = Navigation.findNavController(view);
                 // nav.navigate(R.id.action_groupSearch_to_userSearch);
             }

--- a/feature/src/main/java/org/maru/muaring/feature/search/ui/model/SearchResultItem.java
+++ b/feature/src/main/java/org/maru/muaring/feature/search/ui/model/SearchResultItem.java
@@ -12,10 +12,12 @@ public class SearchResultItem {
     private final Type type;
     private final Long id;
     private final String title;
+    private String imageUrl;
     private final List<String> categoryNames;   // 그룹용
     private final String todayMusicText;        // 사용자용
     private String actionText;                  // 버튼 텍스트
-    private Boolean isJoined;                   // 가입 여부
+    private Boolean isJoined;                   // 가입 여부 (그룹 전용)
+    private Boolean isFollowing;                // 팔로우 여부 (멤버 전용)
 
     public SearchResultItem(Type type,
                             Long id,
@@ -23,7 +25,9 @@ public class SearchResultItem {
                             List<String> categoryNames,
                             String todayMusicText,
                             String actionText,
-                            Boolean isJoined) {
+                            Boolean isJoined,
+                            Boolean isFollowing,
+                            String imageUrl) {
         this.type = type;
         this.id = id;
         this.title = title;
@@ -31,6 +35,8 @@ public class SearchResultItem {
         this.todayMusicText = todayMusicText;
         this.actionText = actionText;
         this.isJoined = isJoined;
+        this.isFollowing = isFollowing;
+        this.imageUrl = imageUrl;
     }
 
     public Type getType() { return type; }
@@ -40,6 +46,8 @@ public class SearchResultItem {
     public String getTodayMusicText() { return todayMusicText; }
     public String getActionText() { return actionText; }
     public Boolean getIsJoined() { return isJoined; }
+    public Boolean getIsFollowing() { return isFollowing; }
+    public String getImageUrl() { return imageUrl; }
 
     // setter
     public void setActionText(String actionText) {
@@ -48,4 +56,8 @@ public class SearchResultItem {
     public void setIsJoined(Boolean joined) {
         this.isJoined = joined;
     }
+    public void setIsFollowing(Boolean isFollowing) {
+        this.isFollowing = isFollowing;
+    }
+    public void setImageUrl(String imageUrl) { this.imageUrl = imageUrl; }
 }

--- a/feature/src/main/res/layout/fragment_search.xml
+++ b/feature/src/main/res/layout/fragment_search.xml
@@ -9,26 +9,25 @@
     android:background="@color/surface"
     android:layout_marginTop="20dp">
 
-    <!-- 뒤로가기 -->
-    <ImageButton
-        android:id="@+id/btn_back"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
-        android:background="@android:color/transparent"
-        android:src="@drawable/ic_arrow_back"
-        android:contentDescription="뒤로가기"
+    <!-- 툴바 -->
+    <include
+        android:id="@+id/include_toolbar_group"
+        layout="@layout/toolbar_common"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
 
     <!-- 그룹 / 사용자 토글 -->
     <org.maru.muaring.core.ui.SegmentedToggleView
         android:id="@+id/segmentedToggle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/btn_back"
+        app:layout_constraintTop_toBottomOf="@id/include_toolbar_group"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="20dp" />
+        android:layout_marginTop="30dp" />
 
     <!-- 제목 -->
     <TextView
@@ -69,5 +68,19 @@
         android:layout_marginTop="16dp"
         android:clipToPadding="false"
         android:paddingBottom="16dp" />
+
+    <!-- 검색 결과 없음 표시 -->
+    <TextView
+        android:id="@+id/tvEmptyResult"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="검색 결과가 없습니다."
+        android:textColor="@color/text_light_gray"
+        android:textSize="14sp"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/fragmentSearchBar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="32dp"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/feature/src/main/res/layout/view_search_user_extra.xml
+++ b/feature/src/main/res/layout/view_search_user_extra.xml
@@ -19,11 +19,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="4dp"
+        android:paddingRight="5dp"
         android:text="오늘의 음악을 등록하지 않았습니다."
         android:textSize="12sp"
         android:textColor="@color/text_today_music"
         android:includeFontPadding="false"
         android:gravity="center_vertical"
-        android:paddingBottom="2sp"/>
+        android:paddingBottom="2sp"
+        android:singleLine="true"
+        android:ellipsize="end" />
 
 </LinearLayout>


### PR DESCRIPTION
## 📌 관련 이슈
#2

## ✨ 작업 내용
- 사용자를 검색할 수 있습니다.
- 사용자 검색 후 팔로우 여부에 따라 팔로우 또는 언팔로우를 할 수 있습니다. (사용자 프로필로 넘어가는 로직은 아직 구현하지 않았습니다)

## 📸 스크린샷(선택)
<img width="540" height="1200" alt="Screenshot_20251207_201904" src="https://github.com/user-attachments/assets/6acf6880-32cc-4ca9-a9f5-6d4b62d67f26" />
<img width="540" height="1200" alt="Screenshot_20251208_004817" src="https://github.com/user-attachments/assets/c79701d6-cc6f-4150-859c-e3b91a40320f" />
<img width="540" height="1200" alt="Screenshot_20251208_004828" src="https://github.com/user-attachments/assets/15870677-cbff-4716-9d16-28afbae2bed7" />


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
- 그룹 검색창 활성화 시 아래 nav바가 안 나오는데 아마 제 창에서만 안 나오는 게 아닐 거라 고쳐둬야 할 것 같습니다!!!