### PR TITLE
#13 [FEAT] 인근 사용자 탐색 연결

### DIFF
--- a/feature/src/main/java/org/maru/muaring/feature/home/ui/HomeFragment.java
+++ b/feature/src/main/java/org/maru/muaring/feature/home/ui/HomeFragment.java
@@ -6,12 +6,14 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
+import androidx.navigation.fragment.NavHostFragment;
 import androidx.recyclerview.widget.DefaultItemAnimator;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -41,6 +43,7 @@ public class HomeFragment extends Fragment implements GroupSelectorAdapter.Liste
     private HomeViewModel viewModel;
     private RecyclerView rvGroupSelector;
     private GroupSelectorAdapter groupSelectorAdapter;
+    private ImageView ivHomeIcon;
 
     @Inject
     GroupRepository groupRepository;
@@ -73,6 +76,14 @@ public class HomeFragment extends Fragment implements GroupSelectorAdapter.Liste
 
         // 기본으로 "나"의 오늘의 음악 보여주기
         showTodayPostsFragment(null);
+
+        View header = view.findViewById(R.id.include_home_header);
+        ivHomeIcon = header.findViewById(org.maru.muaring.design.R.id.ivHomeIcon);
+        ivHomeIcon.setOnClickListener(v -> {
+            NavHostFragment
+                    .findNavController(this)
+                    .navigate(R.id.mapFragment);
+        });
     }
 
     private void observeMyProfileSettings() {

--- a/feature/src/main/java/org/maru/muaring/feature/nearby/ui/MapFragment.java
+++ b/feature/src/main/java/org/maru/muaring/feature/nearby/ui/MapFragment.java
@@ -17,6 +17,7 @@ import androidx.annotation.Nullable;
 import androidx.cardview.widget.CardView;
 import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.Fragment;
+import androidx.navigation.fragment.NavHostFragment;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
@@ -235,7 +236,15 @@ public class MapFragment extends Fragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        adapter = new MusicAdapter(requireContext(), musicList);
+        adapter = new MusicAdapter(requireContext(), musicList, memberId -> {
+            Bundle bundle = new Bundle();
+            bundle.putLong("memberId", memberId);
+
+            NavHostFragment
+                    .findNavController(this)
+                    .navigate(R.id.memberProfileFragment, bundle);
+        });
+
         rvMusic.setLayoutManager(new LinearLayoutManager(getContext()));
         rvMusic.setAdapter(adapter);
     }

--- a/feature/src/main/java/org/maru/muaring/feature/nearby/ui/MusicAdapter.java
+++ b/feature/src/main/java/org/maru/muaring/feature/nearby/ui/MusicAdapter.java
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.bumptech.glide.Glide;
 
 import org.maru.muaring.feature.R;
+import org.maru.muaring.feature.follow.ui.FollowAdapter;
 import org.maru.muaring.feature.nearby.ui.model.Music;
 
 import java.util.List;
@@ -21,9 +22,12 @@ public class MusicAdapter extends RecyclerView.Adapter<MusicAdapter.MusicViewHol
 
     private List<Music> musicList;
     private Context context;
-    public MusicAdapter(Context context, List<Music> musicList) {
+    private OnProfileClickListener profileClickListener;
+
+    public MusicAdapter(Context context, List<Music> musicList, OnProfileClickListener profileClickListener) {
         this.context = context;
         this.musicList = musicList;
+        this.profileClickListener = profileClickListener;
     }
 
     public static class MusicViewHolder extends RecyclerView.ViewHolder {
@@ -72,10 +76,21 @@ public class MusicAdapter extends RecyclerView.Adapter<MusicAdapter.MusicViewHol
                     .load(item.getProfileImageUrl())
                     .into(holder.ivProfile);
         }
+
+        holder.ivProfile.setOnClickListener(v -> {
+            if (profileClickListener != null) {
+                profileClickListener.onProfileClick(item.getMemberId());
+            }
+        });
     }
 
     @Override
     public int getItemCount() {
         return musicList.size();
     }
+
+    public interface OnProfileClickListener {
+        void onProfileClick(long memberId);
+    }
+
 }

--- a/feature/src/main/res/layout/fragment_home.xml
+++ b/feature/src/main/res/layout/fragment_home.xml
@@ -9,6 +9,7 @@
 
     <!-- 홈 상단 로고 + 알림 -->
     <include
+        android:id="@+id/include_home_header"
         layout="@layout/view_home_header" />
 
     <!-- 상단: 나 / 그룹 / 그룹들 / + -->

--- a/feature/src/main/res/layout/fragment_map.xml
+++ b/feature/src/main/res/layout/fragment_map.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/mapFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto">


### PR DESCRIPTION
## 📌 관련 이슈
#13 

## ✨ 작업 내용
홈화면의 아이콘과 인근 사용자 탐색화면 연결하였습니다
인근 사용자 리스트에서 프로필 이미지 클릭 시 해당 멤버의 프로필로 이동하도록 하였습니다

## 📸 스크린샷(선택)
스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
참고, 논의할 사항이 있다면 적어주세요